### PR TITLE
update: add std libs

### DIFF
--- a/templates/util.h.tml
+++ b/templates/util.h.tml
@@ -2,6 +2,8 @@
 #define _UTIL_H_
 
 #include <vector>
+#include <stdio.h>
+#include <stdlib.h>
 
 std::vector<char> {{ index .V "base64_decode" }}(const unsigned char*, size_t);
 


### PR DESCRIPTION
`x86_64-w64-mingw32-g++` gcc version 12 20220819 requires these two libraries to compile successfully.